### PR TITLE
BonDriver_DVB: 休止チャンネルなどでCloseTuner()がブロックするのを修正

### DIFF
--- a/BonDriver_DVB.h
+++ b/BonDriver_DVB.h
@@ -33,6 +33,7 @@ namespace BonDriver_DVB {
 #define TS_BUFSIZE			(TS_PKTSIZE * 256)
 #define TS_FIFOSIZE			512
 #define WAIT_TIME			10	// デバイスからのread()でエラーが発生した場合の、次のread()までの間隔(ms)
+#define WAIT_TIME_BLOCKING	500	// デバイスからのread()がブロックする場合に待機する長さ(ms)。1000未満であること。
 #define TUNER_NAME			"BonDriver_DVB"
 
 ////////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
`/dev/dvb/adapter?/dvr0`をブロッキングI/Oで使用すると、放送休止チャンネルに変更したり受信中に休止した場合にCloseTuner()が永久にブロックしてしまいます(受信中にアンテナを引っこ抜くと手っ取り早く再現できます)。
VT20(PX-S1UDの姉妹品)で挙動を確認しました。

BonDriver_LinuxPTのほうもたぶん同様ですが、LinuxTVで厳に定義されるDVBのキャラクタデバイスと異なりO_NONBLOCKが実装されているかどうか不明のため現状維持としました。
PT系は所有しておらずよく分からないですが、https://github.com/m-tsudo/pt3/blob/master/pt3_pci.c を読むかぎりO_NONBLOCKフラグは見ていないのでread()が同様にブロックするならば打つ手なしと思います。
